### PR TITLE
correcting the way for getting domain availibility from ucs central

### DIFF
--- a/ucscentralsdk/utils/ucscentralbackup.py
+++ b/ucscentralsdk/utils/ucscentralbackup.py
@@ -330,7 +330,7 @@ def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
     from ..mometa.mgmt.MgmtBackupOperation import MgmtBackupOperation, \
         MgmtBackupOperationConsts
     from ..mometa.mgmt.MgmtBackup import MgmtBackupConsts
-    from .ucscentraldomain import get_domain
+    from .ucscentraldomain import get_domain, is_domain_available
 
     preserve_pooled_values = False
 
@@ -351,13 +351,14 @@ def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
                 "file_name must be .xml format")
 
     domain = get_domain(handle, domain_ip, domain_name)
-    if (domain.available_physical_cnt == str(0)):
+
+    if is_domain_available(handle, domain.id):
+        domain_dn = domain.dn
+    else:
         raise UcsCentralValidationException("Domain with IP %s or name %s not "
                                             "registered or lost visibility "
                                             "with UcsCentral" %
                                             (domain_ip, domain_name))
-    else:
-        domain_dn = domain.dn
 
     file_path = file_dir + file_name
 

--- a/ucscentralsdk/utils/ucscentraldomain.py
+++ b/ucscentralsdk/utils/ucscentraldomain.py
@@ -75,7 +75,7 @@ def domain_register_to_ucscentral(handle, domain_name_or_ip,
 
 def get_domain(handle, domain_ip, domain_name=None):
     """
-    This method gets the DN for the Ucs domain.
+    This method gets the computeSystem object for the Ucs domain.
 
     Args:
         handle (UcsCentralHandle): UcsCentral Connection handle
@@ -86,8 +86,8 @@ def get_domain(handle, domain_ip, domain_name=None):
         domain object
 
     Example:
-        get_domain_dn(handle, domain_ip="192.168.1.1", domain_name=" ")
-        get_domain_dn(handle, domain_ip=None, domain_name="test-dom")
+        get_domain(handle, domain_ip="192.168.1.1", domain_name=" ")
+        get_domain(handle, domain_ip=None, domain_name="test-dom")
     """
 
     if domain_ip:
@@ -99,11 +99,39 @@ def get_domain(handle, domain_ip, domain_name=None):
         class_id='ComputeSystem', filter_str=filter_str)
 
     if ((len(domain) != 1)):
-        raise UcsCentralValidationException("Domain with IP %s or name %s does"
-                                            "not exist" %
+        raise UcsCentralValidationException("Domain with IP %s or name %s "
+                                            "does not exist" %
                                             (domain_ip, domain_name))
 
     return domain[0]
+
+
+def is_domain_available(handle, domain_id):
+    """
+    This method returns True if domain is available currently
+    else returns False
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        domain_id(str): ID of domain from domain object
+
+    Returns:
+        True or False depending on domain's availability
+
+    Example:
+        is_domain_available(handle, domain_id="1008")
+    """
+
+    extpol_client_dn = "extpol/reg/clients/client-" + domain_id
+    extpol_client = handle.query_dn(extpol_client_dn)
+
+    if extpol_client is not None:
+        if extpol_client.oper_state == "registered":
+            return True
+        else:
+            return False
+    else:
+        return False
 
 
 def domain_group_create(handle, name,

--- a/ucscentralsdk/utils/ucscentraltechsupport.py
+++ b/ucscentralsdk/utils/ucscentraltechsupport.py
@@ -403,17 +403,17 @@ def get_domain_tech_support(handle, domain_ip,
 
     """
 
-    from .ucscentraldomain import get_domain
+    from .ucscentraldomain import get_domain, is_domain_available
 
-    # create SysdebugTechSupport
     domain = get_domain(handle, domain_ip, domain_name)
-    if (domain.available_physical_cnt == str(0)):
+
+    if is_domain_available(handle, domain.id):
+        domain_dn = domain.dn
+    else:
         raise UcsCentralValidationException(
             "Domain with IP %s or name %s not registered or "
             "lost visibility with ucscentral" %
             (domain_ip, domain_name))
-    else:
-        domain_dn = domain.dn
 
     creation_ts = _get_creation_ts()
     ts_domain_mo = _bootstrap_domain_tech_support_mo(


### PR DESCRIPTION
The way for getting domain available status was not correct in current code.
So correcting it via this PR. Getting it via extPolClient's oper state instead of computeSystem's available physical count property.

Signed-off-by: Parag Shah <parag.may4@gmail.com>