### PR TITLE
fixing query_dn by using config_resolve_dn instead of dns

### DIFF
--- a/ucscentralsdk/ucscentralcoreutils.py
+++ b/ucscentralsdk/ucscentralcoreutils.py
@@ -286,10 +286,19 @@ def extract_molist_from_method_response(method_response,
     """
 
     mo_list = []
-    if len(method_response.out_configs.child) == 0:
+
+    if hasattr(method_response, "out_config"):
+        resp_configs = method_response.out_config
+    elif hasattr(method_response, "out_configs"):
+        resp_configs = method_response.out_configs
+    else:
+        log.error("method_response should contain out_config(s)")
+        return mo_list
+
+    if len(resp_configs.child) == 0:
         return mo_list
     if in_hierarchical:
-        current_mo_list = method_response.out_configs.child
+        current_mo_list = resp_configs.child
         while len(current_mo_list) > 0:
             child_mo_list = []
             for mo in current_mo_list:
@@ -302,7 +311,7 @@ def extract_molist_from_method_response(method_response,
                         break
             current_mo_list = child_mo_list
     else:
-        mo_list = method_response.out_configs.child
+        mo_list = resp_configs.child
 
     return mo_list
 

--- a/ucscentralsdk/ucscentralhandle.py
+++ b/ucscentralsdk/ucscentralhandle.py
@@ -335,20 +335,14 @@ class UcsCentralHandle(UcsCentralSession):
                                        need_response=True)\n
         """
 
-        from .ucscentralbasetype import DnSet, Dn
-        from .ucscentralmethodfactory import config_resolve_dns
+        from .ucscentralmethodfactory import config_resolve_dn
 
         if not dn:
             raise ValueError("Provide dn.")
 
-        dn_set = DnSet()
-        dn_obj = Dn()
-        dn_obj.value = dn
-        dn_set.child_add(dn_obj)
-
-        elem = config_resolve_dns(cookie=self.cookie,
-                                  in_dns=dn_set,
-                                  in_hierarchical=hierarchy)
+        elem = config_resolve_dn(cookie=self.cookie,
+                                 dn=dn,
+                                 in_hierarchical=hierarchy)
         response = self.post_elem(elem, dme=dme)
         if response.error_code != 0:
             raise UcsCentralException(response.error_code, response.error_descr)
@@ -364,8 +358,8 @@ class UcsCentralHandle(UcsCentralSession):
             return out_mo_list
 
         mo = None
-        if len(response.out_configs.child) > 0:
-            mo = response.out_configs.child[0]
+        if len(response.out_config.child) > 0:
+            mo = response.out_config.child[0]
         return mo
 
     def query_classid(self, class_id=None, filter_str=None, hierarchy=False,


### PR DESCRIPTION
- query_dn was using config_resolve_dns which doesn't work with hierarchy in back end itself.
- So correcting query_dn to use config_resolve_dn so that query_dn with hierarchy can work at least.
- query_dns with hierarchy will still face issue as back end have issue with that. This should get fixed whenever back end fixes it.

Signed-off-by: Parag Shah <parag.may4@gmail.com>