### PR TITLE
Fix for local download not supported from 1.5 version onwards

### DIFF
--- a/ucscentralsdk/utils/ucscentralbackup.py
+++ b/ucscentralsdk/utils/ucscentralbackup.py
@@ -63,6 +63,7 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
     """
     from ..mometa.mgmt.MgmtBackup import MgmtBackup, MgmtBackupConsts
     from ..mometa.top.TopSystem import TopSystem
+    from .ucscentralfirmware import is_local_download_supported
 
     backup_type = "full-state"
     preserve_pooled_values = False
@@ -143,16 +144,20 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
 
     if not remote_enabled:
         file_source = "backupfile" + file_path
-        try:
-            handle.file_download(url_suffix=file_source,
-                                 file_dir=file_dir,
-                                 file_name=file_name)
-        except Exception as err:
-            UcsCentralWarning(str(err))
-            handle.remove_mo(mgmt_backup)
-            handle.commit()
-            raise UcsCentralOperationError(
-                  "Download backup", "download failed")
+        if is_local_download_supported(handle):
+            try:
+                handle.file_download(url_suffix=file_source,
+                                     file_dir=file_dir,
+                                     file_name=file_name)
+            except Exception as err:
+                UcsCentralWarning(str(err))
+                handle.remove_mo(mgmt_backup)
+                handle.commit()
+                raise UcsCentralOperationError(
+                      "Download backup", "download failed")
+        else:
+            log.debug("Local Download not supported for this version "
+                      "of ucscentral")
 
     # remove backup from ucscentral
     handle.remove_mo(mgmt_backup)
@@ -199,6 +204,7 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
     from ..mometa.mgmt.MgmtDataExporter import MgmtDataExporter, \
         MgmtDataExporterConsts
     from ..mometa.top.TopSystem import TopSystem
+    from .ucscentralfirmware import is_local_download_supported
 
     backup_type = "config-all"
     if not file_dir:
@@ -277,16 +283,20 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
 
     if not remote_enabled:
         file_source = "backupfile" + file_path
-        try:
-            handle.file_download(url_suffix=file_source,
-                                 file_dir=file_dir,
-                                 file_name=file_name)
-        except Exception as err:
-            UcsCentralWarning(str(err))
-            handle.remove_mo(mgmt_export)
-            handle.commit()
-            raise UcsCentralOperationError(
-                "Download of config_export", "download failed")
+        if is_local_download_supported(handle):
+            try:
+                handle.file_download(url_suffix=file_source,
+                                     file_dir=file_dir,
+                                     file_name=file_name)
+            except Exception as err:
+                UcsCentralWarning(str(err))
+                handle.remove_mo(mgmt_export)
+                handle.commit()
+                raise UcsCentralOperationError(
+                    "Download of config_export", "download failed")
+        else:
+            log.debug("Local download is not supported for this version "
+                      "of ucscentral")
 
     # remove backup from ucs
     handle.remove_mo(mgmt_export)

--- a/ucscentralsdk/utils/ucscentralfirmware.py
+++ b/ucscentralsdk/utils/ucscentralfirmware.py
@@ -572,3 +572,48 @@ def sync_firmware_update_from_cisco(handle, cisco_username, cisco_password,
 
     handle.set_mo(sync_fw_update)
     handle.commit()
+
+
+def get_ucscentral_version(handle):
+    """
+    This method returns version of Ucs Central.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+
+    Returns:
+        Version string
+
+    Example:
+        get_ucscentral_version(handle):
+    """
+
+    version_obj = handle.query_classid(class_id="VersionApplication")
+
+    if len(version_obj) != 1:
+        raise UcsCentralOperationError("Getting Version","Failed")
+    else:
+        return version_obj[0].version
+
+
+def is_local_download_supported(handle):
+    """
+    This method returns True/False depending on whether this version of
+    UcsCentral supports local download or not
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+
+    Returns:
+        True/False
+
+    Example:
+        is_local_download_supported(handle)
+    """
+
+    version = get_ucscentral_version(handle)
+
+    if version.startswith("1.5"):
+        return False
+    else:
+        return True

--- a/ucscentralsdk/utils/ucscentraltechsupport.py
+++ b/ucscentralsdk/utils/ucscentraltechsupport.py
@@ -159,6 +159,8 @@ def get_ucscentral_tech_support(handle, file_dir=None, file_name=None,
                                 download=True,
                                 timeout=1200):
 
+    from .ucscentralfirmware import is_local_download_supported
+
     if download:
         _validate_download_args(file_dir, file_name)
         _create_download_dir(file_dir)
@@ -177,8 +179,12 @@ def get_ucscentral_tech_support(handle, file_dir=None, file_name=None,
     log.debug("Techsupport creation completed")
     # download tech support file
     if download:
-        download_tech_support(handle, ts_mo.name, file_dir, file_name)
-        log.debug("Downloading techsupport complete")
+        if is_local_download_supported(handle):
+            download_tech_support(handle, ts_mo.name, file_dir, file_name)
+            log.debug("Downloading techsupport complete")
+        else:
+            log.debug("Local download is not supported for this "
+                      "ucscentral version")
 
     # remove tech support file from Ucs Central
     if remove_from_ucscentral:


### PR DESCRIPTION
-> Back-end has stopped supporting local download from 1.5 release onwards, so restricting the same with SDK as well and not throwing exception if local download is tried with 1.5
-> This is raised as https://github.com/CiscoUcs/ucscentralsdk/issues/20 


Signed-off-by: Parag Shah <parag.may4@gmail.com>
