### PR TITLE
Enhancing get_meta and set_prop to simplify exist and modify APIs

### DIFF
--- a/ucscentralsdk/ucscentralcoreutils.py
+++ b/ucscentralsdk/ucscentralcoreutils.py
@@ -502,6 +502,8 @@ class ClassIdMeta(object):
             include_prop=True,
             show_tree=True,
             depth=None):
+        from ucscentralsdk import ucscentralcoremeta
+
         self.__mo_meta = MO_CLASS_META[class_id]
         self.class_id = class_id
         self.xml_attribute = self.__mo_meta.xml_attribute
@@ -512,6 +514,8 @@ class ClassIdMeta(object):
         self.parents = self.__mo_meta.parents
         self.children = self.__mo_meta.children
         self.props = {}
+        self.all_props = []
+        self.config_props = []
 
         self._str_tree = "\n"
         self._str_props = "\n"
@@ -524,6 +528,10 @@ class ClassIdMeta(object):
             self.props = class_obj.prop_meta
             for prop in sorted(self.props):
                 self._str_props += str(self.props[prop]) + "\n"
+                self.all_props.append(str(prop))
+                if self.props[prop].access == \
+                        ucscentralcoremeta.MoPropertyMeta.READ_WRITE:
+                    self.config_props.append(str(prop))
 
     def __str__(self):
         """
@@ -549,7 +557,12 @@ class ClassIdMeta(object):
             self.access_privilege) + "\n"
         out_str += str("parents").ljust(ts * 4) + ':' + str(self.parents) + \
             "\n"
-        out_str += str("children").ljust(ts * 4) + ':' + str(self.children)
+        out_str += str("children").ljust(ts * 4) + ':' + str(self.children) + \
+            "\n"
+        out_str += str("properties").ljust(ts * 4) + ':' + str(self.all_props)\
+            + "\n"
+        out_str += str("configurable properties").ljust(ts * 4) + ':' + \
+            str(self.config_props)
 
         out_str += self._str_props
 

--- a/ucscentralsdk/ucscentralmo.py
+++ b/ucscentralsdk/ucscentralmo.py
@@ -188,6 +188,31 @@ class ManagedObject(UcsCentralBase):
                 self._dirty_mask |= prop_meta.mask
         object.__setattr__(self, name, value)
 
+    def __get_prop(self, name):
+        return object.__getattribute__(self, name)
+
+    def check_prop_match(self, **kwargs):
+        for prop_name in kwargs:
+            if prop_name not in self.prop_meta.keys():
+                raise ValueError("Invalid Property Name Exception - "
+                                 "[%s]: Prop <%s> "
+                                 % (self.__class__.__name__,
+                                    prop_name))
+
+            if kwargs[prop_name] != self.__get_prop(prop_name):
+                return False
+        return True
+
+    def set_prop_multiple(self, **kwargs):
+        for prop_name in kwargs:
+            if prop_name not in self.prop_meta.keys():
+                raise ValueError("Invalid Property Name Exception - "
+                                 "[%s]: Prop <%s> "
+                                 % (self.__class__.__name__,
+                                    prop_name))
+
+            self.__set_prop(prop_name, kwargs[prop_name])
+
     def __str__(self):
         """
         Method to return string representation of a managed object.

--- a/ucscentralsdk/utils/ucscentraldomain.py
+++ b/ucscentralsdk/utils/ucscentraldomain.py
@@ -39,8 +39,14 @@ def domain_register(handle, domain_name_or_ip,
                         username="admin",password="password")
     """
 
+    from distutils.version import LooseVersion as VERSION
+    from .ucscentralfirmware import get_ucscentral_version
     from ucscentralsdk.mometa.policy.PolicyControlEpOp import\
         PolicyControlEpOp, PolicyControlEpOpConsts
+
+    if VERSION(get_ucscentral_version(handle)) < VERSION("1.5"):
+        raise UcsCentralValidationException("Operation only supported from "
+            "version 1.5 onwards")
 
     if is_domain_registered(handle, domain_name_or_ip):
         domain_dn = "holder/domain-ep/control-ep-" + domain_name_or_ip
@@ -128,8 +134,14 @@ def domain_unregister(handle, domain_name_or_ip):
         domain_unregister(handle, domain_name_or_ip="192.168.1.1")
     """
 
+    from distutils.version import LooseVersion as VERSION
+    from .ucscentralfirmware import get_ucscentral_version
     from ucscentralsdk.mometa.policy.PolicyControlEpOp import\
         PolicyControlEpOpConsts
+
+    if VERSION(get_ucscentral_version(handle)) < VERSION("1.5"):
+        raise UcsCentralValidationException("Operation only supported from "
+            "version 1.5 onwards")
 
     filter_str = '(host_name_or_ip, %s, type="eq")' % domain_name_or_ip
 

--- a/ucscentralsdk/utils/ucscentralfirmware.py
+++ b/ucscentralsdk/utils/ucscentralfirmware.py
@@ -611,9 +611,9 @@ def is_local_download_supported(handle):
         is_local_download_supported(handle)
     """
 
-    version = get_ucscentral_version(handle)
+    from distutils.version import LooseVersion as VERSION
 
-    if version.startswith("1.5"):
+    if VERSION(get_ucscentral_version(handle)) >= VERSION("1.5"):
         return False
-    else:
-        return True
+
+    return True


### PR DESCRIPTION
Enhancing get_meta and set_prop to simplify exist and modify APIs:
- get_meta info now gives list of config_props and all_props
- set_prop_multiple() -> This will take name, value pair and set the multiple properties of the MO.
- check_prop_match() -> This will take name, value pair and returns if the given property name, value pair exactly match with MO's property value.
- Putting check on register_domain() and unregister_domain() for raising exception with version lower than 1.5.