### PR TITLE
schedule backup/export_confg APIs and other backup related API changes

### DIFF
--- a/ucscentralsdk/ucscentralmo.py
+++ b/ucscentralsdk/ucscentralmo.py
@@ -195,9 +195,8 @@ class ManagedObject(UcsCentralBase):
         for prop_name in kwargs:
             if prop_name not in self.prop_meta.keys():
                 raise ValueError("Invalid Property Name Exception - "
-                                 "[%s]: Prop <%s> "
-                                 % (self.__class__.__name__,
-                                    prop_name))
+                                 "Class [%s]: Prop <%s> "
+                                 % (self.__class__.__name__, prop_name))
 
             if kwargs[prop_name] != self.__get_prop(prop_name):
                 return False
@@ -206,12 +205,12 @@ class ManagedObject(UcsCentralBase):
     def set_prop_multiple(self, **kwargs):
         for prop_name in kwargs:
             if prop_name not in self.prop_meta.keys():
-                raise ValueError("Invalid Property Name Exception - "
-                                 "[%s]: Prop <%s> "
-                                 % (self.__class__.__name__,
-                                    prop_name))
-
-            self.__set_prop(prop_name, kwargs[prop_name])
+                log.warning("Invalid Property Name for "
+                            "Class [%s]: Prop <%s>, setting it forcefully"
+                            % (self.__class__.__name__, prop_name))
+                self.__set_prop(prop_name, kwargs[prop_name], forced=True)
+            else:
+                self.__set_prop(prop_name, kwargs[prop_name])
 
     def __str__(self):
         """

--- a/ucscentralsdk/utils/ucscentralbackup.py
+++ b/ucscentralsdk/utils/ucscentralbackup.py
@@ -27,19 +27,37 @@ from ..ucscentralexception import UcsCentralValidationException, \
 log = logging.getLogger('ucscentral')
 
 
-def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
-                      remote_enabled=False, protocol=None,
-                      host_name="localhost", username=None, password=None,
-                      preserve_pooled_values=False):
+ucscentral_base_dn = "org-root/deviceprofile-default"
+
+
+def _validate_remote_host_args(protocol, hostname, username, password):
+    if not protocol:
+        raise UcsCentralValidationException("Missing protocol argument")
+    if not hostname:
+        raise UcsCentralValidationException("Missing hostname argument")
+    if protocol == 'tftp':
+        return
+
+    if not username:
+        raise UcsCentralValidationException("Missing username argument")
+    if not password:
+        raise UcsCentralValidationException("Missing password argument")
+
+
+def _backup(handle, file_dir, file_name, timeout=600,
+            remote_enabled=False, protocol=None,
+            hostname="localhost", username=None, password="",
+            remove_from_ucscentral=False,
+            preserve_pooled_values=False):
     """
-    backup_ucscentral helps create and download UcsCentral full-state backup.
+    _backup internal method helps create UcsCentral full-state backup and
+    download it locally or to remote location.
 
     Args:
         handle (UcsCentralHandle): UcsCentral Connection handle
-        file_dir (str): directory to download ucs backup file to
+        file_dir (str): directory to download backup file to
         file_name (str): name for the backup file
-                         (supported file extension '.tgz')
-        timeout_in_sec (number) : time in seconds for which method waits
+        timeout (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         remote_enabled (boolean): True if Remote backup is enabled
                                   False - by default
@@ -48,17 +66,17 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
         hostname (str): Hostname/IP for the remote backup
         username (str): Username for remote backup
         password (str): Password for remote backup
-        preserve_pooled_values (boolean): True/False,
-                                          False - by default
+        remove_from_ucscentral (boolean): True/False, False - by default
+        preserve_pooled_values (boolean): True/False, False - by default
 
     Example:
         file_dir = "/home/user/backup"\n
         file_name = "config_backup.tgz"\n
-        backup_ucscentral(handle, file_dir=test_support, file_name=file_name)\n
+        _backup(handle, file_dir=file_dir, file_name=file_name)\n
 
-        backup_ucscentral(handle, file_dir=test_support, file_name=file_name,
-                    remote_enabled=True, protocol='scp',hostname='192.168.1.1',
-                    username='admin',password='password')\n
+        _backup(handle, file_dir=file_dir, file_name=file_name,
+                remote_enabled=True, protocol='scp',hostname='192.168.1.1',
+                username='admin',password='password')\n
 
     """
     from ..mometa.mgmt.MgmtBackup import MgmtBackup, MgmtBackupConsts
@@ -76,6 +94,7 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
     top_system = TopSystem()
 
     if remote_enabled:
+        _validate_remote_host_args(protocol, hostname, username, password)
         if (not file_name.endswith('.tgz')):
             raise UcsCentralValidationException(
                 "file_name must be .tgz format")
@@ -83,7 +102,7 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
         file_path = os.path.join(file_dir, file_name)
         mgmt_backup = MgmtBackup(
                 parent_mo_or_dn=top_system,
-                hostname=host_name,
+                hostname=hostname,
                 admin_state=MgmtBackupConsts.ADMIN_STATE_ENABLED,
                 proto=protocol,
                 type=backup_type,
@@ -100,7 +119,7 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
 
         mgmt_backup = MgmtBackup(
                 parent_mo_or_dn=top_system,
-                hostname=host_name,
+                hostname=hostname,
                 admin_state=MgmtBackupConsts.ADMIN_STATE_ENABLED,
                 proto=MgmtBackupConsts.PROTO_HTTP,
                 type=backup_type,
@@ -119,7 +138,7 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
     mgmt_backup = handle.query_dn(dn=mgmt_backup.dn)
     admin_state_temp = mgmt_backup.admin_state
     # Checking for the backup to compete.
-    duration = timeout_in_sec
+    duration = timeout
     poll_interval = 2
 
     log.debug("Starting Backup ")
@@ -140,12 +159,13 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
                   "Backup UcsCentral", " operation timed out")
 
     # download backup
-    log.debug("Backup done, starting Download ")
+    log.debug("Backup done")
 
     if not remote_enabled:
         file_source = "backupfile" + file_path
         if is_local_download_supported(handle):
             try:
+                log.debug("Starting Download ")
                 handle.file_download(url_suffix=file_source,
                                      file_dir=file_dir,
                                      file_name=file_name)
@@ -156,28 +176,99 @@ def backup_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
                 raise UcsCentralOperationError(
                       "Download backup", "download failed")
         else:
-            log.debug("Local Download not supported for this version "
-                      "of ucscentral")
+            log.error("Local download not supported from sdk for this "
+                      "version of UcsCentral, skipping it")
 
-    # remove backup from ucscentral
-    handle.remove_mo(mgmt_backup)
-    handle.commit()
+    if remove_from_ucscentral:
+        # remove backup from ucscentral
+        log.debug("Removing backup from UcsCentral")
+        handle.remove_mo(mgmt_backup)
+        handle.commit()
 
 
-def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
-                             remote_enabled=False, protocol=None,
-                             host_name="localhost", username=None,
-                             password=None, preserve_pooled_values=False):
+def backup_local(handle, file_dir, file_name, preserve_pooled_values=False,
+                 remove_from_ucscentral=False, timeout=600):
     """
-    config_export_ucscentral helps export and download UcsCentral config-all
-    backup.
+    backup_local helps create UcsCentral full-state backup and dowload it
+    locally.
 
     Args:
         handle (UcsCentralHandle): UcsCentral Connection handle
         file_dir (str): directory to download ucs backup file to
         file_name (str): name for the backup file
-                         (supported file extension are '.tar.gz' and '.xml')
-        timeout_in_sec (number) : time in seconds for which method waits
+        preserve_pooled_values (boolean): True/False, False - by default
+        remove_from_ucscentral (boolean): True/False, False - by default
+        timeout (number) : time in seconds for which method waits
+                              for the backUp file to generate before it exits.
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "config_backup.tgz"\n
+        backup_local(handle, file_dir=test_support, file_name=file_name)\n
+    """
+
+    _backup(handle, file_dir=file_dir, file_name=file_name,
+            remote_enabled=False, hostname="localhost",
+            preserve_pooled_values=preserve_pooled_values,
+            remove_from_ucscentral=remove_from_ucscentral,
+            timeout=timeout)
+
+
+def backup_remote(handle, file_dir, file_name, hostname,
+                  protocol="scp", username=None, password="",
+                  preserve_pooled_values=False,
+                  remove_from_ucscentral=False,
+                  timeout=600):
+    """
+    backup_remote helps create and download UcsCentral full-state backup to
+    remote location.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        file_dir (str): directory to download ucs backup file to
+        file_name (str): name for the backup file
+                         (supported file extension '.tgz')
+        hostname (str): Hostname/IP for the remote backup
+        protocol (str): Transfer protocol for remote backup
+                        ['ftp','sftp','tftp','scp']
+        username (str): Username for remote backup
+        password (str): Password for remote backup
+        preserve_pooled_values (boolean): True/False, False - by default
+        remove_from_ucscentral (boolean): True/False, False - by default
+        timeout (number) : time in seconds for which method waits
+                              for the backUp file to generate before it exits.
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "config_backup.tgz"\n
+        backup_remote(handle, file_dir=file_dir, file_name=file_name,
+                      protocol='scp',hostname='192.168.1.1',
+                      username='admin',password='password')\n
+
+    """
+    _backup(handle, file_dir=file_dir, file_name=file_name,
+            remote_enabled=True,
+            hostname=hostname, protocol=protocol,
+            username=username, password=password,
+            preserve_pooled_values=preserve_pooled_values,
+            remove_from_ucscentral=remove_from_ucscentral,
+            timeout=timeout)
+
+
+def _export_config(handle, file_dir, file_name, timeout=600,
+                   remote_enabled=False, protocol=None,
+                   hostname="localhost", username=None, password="",
+                   remove_from_ucscentral=False,
+                   preserve_pooled_values=False):
+    """
+    _export_config internal method helps export UcsCentral config-all backup
+    and download it locally or to remote location.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        file_dir (str): directory to download ucs backup file to
+        file_name (str): name for the backup file
+        timeout (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         remote_enabled (boolean): True if Remote backup is enabled
                                   False - by default
@@ -186,16 +277,16 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
         hostname (str): Hostname/IP for the remote backup
         username (str): Username for remote backup
         password (str): Password for remote backup
-        preserve_pooled_values (boolean): True/False,
-                                            False - by default
+        remove_from_ucscentral (boolean): True/False, False - by default
+        preserve_pooled_values (boolean): True/False, False - by default
 
     Example:
         file_dir = "/home/user/backup"\n
-        file_name = "config_export.tgz"\n
-        config_export_ucscentral(handle, file_dir=test_support,
-                                         file_name=file_name)\n
+        file_name = "export_config.tgz"\n
+        _export_config(handle, file_dir=test_support,
+                       file_name=file_name)\n
 
-        config_export_ucscentral(handle, file_dir=test_support,
+        _export_config(handle, file_dir=test_support,
                     file_name=file_name,remote_enabled=True,
                     protocol='scp',hostname='192.168.1.1',
                     username='admin',password='password')\n
@@ -215,6 +306,7 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
     top_system = TopSystem()
 
     if remote_enabled:
+        _validate_remote_host_args(protocol, hostname, username, password)
         if (not file_name.endswith('.tgz')):
             raise UcsCentralValidationException(
                 "file_name must be .tgz format")
@@ -222,7 +314,7 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
         file_path = os.path.join(file_dir, file_name)
         mgmt_export = MgmtDataExporter(
                 parent_mo_or_dn=top_system,
-                hostname=host_name,
+                hostname=hostname,
                 admin_state=MgmtDataExporterConsts.ADMIN_STATE_ENABLED,
                 proto=protocol,
                 type=backup_type,
@@ -239,7 +331,7 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
 
         mgmt_export = MgmtDataExporter(
                 parent_mo_or_dn=top_system,
-                hostname=host_name,
+                hostname=hostname,
                 admin_state=MgmtDataExporterConsts.ADMIN_STATE_ENABLED,
                 proto=MgmtDataExporterConsts.PROTO_HTTP,
                 type=backup_type,
@@ -257,9 +349,9 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
 
     mgmt_export = handle.query_dn(dn=mgmt_export.dn)
     admin_state_temp = mgmt_export.admin_state
-    log.debug("Starting config export ")
+    log.debug("Starting export config")
     # Checking for the backup to compete.
-    duration = timeout_in_sec
+    duration = timeout
     poll_interval = 2
 
     while True:
@@ -279,12 +371,13 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
                 "Config Export UcsCentral", "operation timed out")
 
     # download backup
-    log.debug("Config exported, now Downloading")
+    log.debug("Config exported")
 
     if not remote_enabled:
         file_source = "backupfile" + file_path
         if is_local_download_supported(handle):
             try:
+                log.debug("Starting download")
                 handle.file_download(url_suffix=file_source,
                                      file_dir=file_dir,
                                      file_name=file_name)
@@ -293,39 +386,115 @@ def config_export_ucscentral(handle, file_dir, file_name, timeout_in_sec=600,
                 handle.remove_mo(mgmt_export)
                 handle.commit()
                 raise UcsCentralOperationError(
-                    "Download of config_export", "download failed")
+                    "Download of export_config", "download failed")
         else:
-            log.debug("Local download is not supported for this version "
-                      "of ucscentral")
+            log.error("Local download not supported from sdk for this "
+                      "version of UcsCentral, skipping it")
 
-    # remove backup from ucs
-    handle.remove_mo(mgmt_export)
-    handle.commit()
+    if remove_from_ucscentral:
+        # remove backup from ucscentral
+        log.debug("Removing export config from UcsCentral")
+        handle.remove_mo(mgmt_export)
+        handle.commit()
+
+
+def export_config_local(handle, file_dir, file_name,
+                        preserve_pooled_values=False,
+                        remove_from_ucscentral=False,
+                        timeout=600):
+    """
+    export_config_local helps export UcsCentral config-all backup and download
+    it locally.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        file_dir (str): directory to download ucs backup file to
+        file_name (str): name for the backup file
+        preserve_pooled_values (boolean): True/False, False - by default
+        remove_from_ucscentral (boolean): True/False, False - by default
+        timeout (number) : time in seconds for which method waits
+                              for the backUp file to generate before it exits.
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "export_config.tgz"\n
+        export_config_ucscentral(handle, file_dir=file_dir,
+                                         file_name=file_name)\n
+    """
+
+    _export_config(handle, file_dir=file_dir, file_name=file_name,
+                   remote_enabled=False, hostname="localhost",
+                   preserve_pooled_values=preserve_pooled_values,
+                   remove_from_ucscentral=remove_from_ucscentral,
+                   timeout=timeout)
+
+
+def export_config_remote(handle, file_dir, file_name, hostname,
+                         protocol="scp", username=None, password="",
+                         preserve_pooled_values=False,
+                         remove_from_ucscentral=False,
+                         timeout=600):
+    """
+    export_config_remote helps export UcsCentral config-all backup and
+    download it to remote location.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        file_dir (str): directory to download ucs backup file to
+        file_name (str): name for the backup file
+                         (supported file extension '.tgz')
+        hostname (str): Hostname/IP for the remote backup
+        protocol (str): Transfer protocol for remote backup
+                        ['ftp','sftp','tftp','scp']
+        username (str): Username for remote backup
+        password (str): Password for remote backup
+        preserve_pooled_values (boolean): True/False, False - by default
+        remove_from_ucscentral (boolean): True/False, False - by default
+        timeout (number) : time in seconds for which method waits
+                              for the backUp file to generate before it exits.
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "export_config.tgz"\n
+
+        export_config_remote(handle, file_dir=file_dir,
+                    file_name=file_name,
+                    protocol='scp',hostname='192.168.1.1',
+                    username='admin',password='password')\n
+
+    """
+    _export_config(handle, file_dir=file_dir, file_name=file_name,
+                   remote_enabled=True,
+                   hostname=hostname, protocol=protocol,
+                   username=username, password=password,
+                   preserve_pooled_values=preserve_pooled_values,
+                   remove_from_ucscentral=remove_from_ucscentral,
+                   timeout=timeout)
 
 
 def _fail_and_remove_domain_backup(handle, backup_status_mo, err):
     if backup_status_mo:
         handle.remove_mo(backup_status_mo)
         handle.commit(dme="resource-mgr")
-    raise UcsCentralOperationError("Domain backup/config_export", err)
+    raise UcsCentralOperationError("Domain backup/export_config", err)
 
 
-def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
-                                   domain_ip, domain_name, host_name,
+def _backup_or_exportconfig_domain(handle, backup_type, file_dir, file_name,
+                                   domain_ip, domain_name, hostname,
                                    preserve_pooled_values, protocol,
-                                   username, password, timeout_in_sec):
+                                   username, password, timeout):
     """
     This internal function helps create domain full_state backup or export
     config to remote location
     Note: This is internal function, should use either backup_domain or
-    backup_config_export
+    backup_export_config
     Args:
         handle (UcsCentralHandle): UcsCentral Connection handle
         file_dir (str): directory to download ucs backup file to
         file_name (str): name for the backup file
                          (supported file extension is '.tgz')
         backup_type (str): Either full-state or config-all.
-        timeout_in_sec (number) : time in seconds for which method waits
+        timeout (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         domain_ip(str): IP of domain, set 'None' if domain_name is valid
         domain_name(str): Domain name, valid only if domain_ip is None
@@ -360,22 +529,24 @@ def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
         if (not file_name.endswith('.xml')):
             raise UcsCentralValidationException(
                 "file_name must be .xml format")
+    _validate_remote_host_args(protocol, hostname, username, password)
 
     domain = get_domain(handle, domain_ip, domain_name)
 
     if _is_domain_available(handle, domain.id):
         domain_dn = domain.dn
     else:
-        raise UcsCentralValidationException("Domain with IP %s or name %s not "
-                                            "registered or lost visibility "
-                                            "with UcsCentral" %
-                                            (domain_ip, domain_name))
+        raise UcsCentralOperationError("Backup or Export_config",
+                                       "Domain with IP %s or name %s not "
+                                       "registered or lost visibility "
+                                       "with UcsCentral" %
+                                       (domain_ip, domain_name))
 
     file_path = os.path.join(file_dir, file_name)
 
     mgmt_backup = MgmtBackupOperation(
             parent_mo_or_dn=domain_dn,
-            hostname=host_name,
+            hostname=hostname,
             admin_state=MgmtBackupOperationConsts.ADMIN_STATE_ENABLED,
             proto=protocol,
             type=backup_type,
@@ -396,7 +567,7 @@ def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
     duration = 30
     poll_interval = 2
     backup_status_dn = "extpol/reg/clients/client-" + \
-        domain.id + "/backup-" + host_name
+        domain.id + "/backup-" + hostname
     while True:
         backup_status = handle.query_dn(
             dn=backup_status_dn, dme="resource-mgr")
@@ -407,13 +578,13 @@ def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
         duration = max(0, (duration - poll_interval))
         if duration == 0:
             raise UcsCentralOperationError(
-                "Backup or config export of domain", "not triggered")
+                "Backup or export config of domain", "not triggered")
 
     log.debug("Domain Backup Triggered")
 
     # Checking for the backup to become available.
     log.debug("Waiting for Domain Backup to become available")
-    duration = timeout_in_sec
+    duration = timeout
     poll_interval = 5
 
     while True:
@@ -434,21 +605,21 @@ def _backup_or_configexport_domain(handle, backup_type, file_dir, file_name,
     log.debug("Domain backup is available")
 
 
-def backup_domain(handle, file_dir, file_name,
-                  domain_ip,  protocol, host_name,
-                  username, password,
-                  domain_name=None, preserve_pooled_values=False,
-                  timeout_in_sec=600):
+def backup_domain_remote(handle, file_dir, file_name,
+                         domain_ip,  protocol, hostname,
+                         username=None, password="",
+                         domain_name=None, preserve_pooled_values=False,
+                         timeout=600):
     """
-    backup_domain  helps create domain full_state backup and download it to
-    remote location.
+    backup_domain_remote  helps create domain full_state backup and download
+    it to remote location.
     Note: Domain backup will always be remote backup
     Args:
         handle (UcsCentralHandle): UcsCentral Connection handle
         file_dir (str): directory to download ucs backup file to
         file_name (str): name for the backup file
                          (supported file extension is '.tgz')
-        timeout_in_sec (number) : time in seconds for which method waits
+        timeout (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         domain_ip(str): IP of domain, set 'None' if domain_name is valid
         domain_name(str): Domain name, valid only if domain_ip is None
@@ -464,36 +635,36 @@ def backup_domain(handle, file_dir, file_name,
         file_dir = "/home/user/backup"\n
         file_name = "config_backup.tgz"\n
 
-        backup_domain(handle, file_dir=test_support, file_name=file_name,
+        backup_domain_remote(handle, file_dir=file_dir, file_name=file_name,
                     domain_ip='10.10.10.1', protocol='scp',
                     hostname='192.168.1.1',
                     username='admin',password='password')\n
 
     """
     backup_type = "full-state"
-    return _backup_or_configexport_domain(handle, backup_type, file_dir,
+    return _backup_or_exportconfig_domain(handle, backup_type, file_dir,
                                           file_name, domain_ip, domain_name,
-                                          host_name, preserve_pooled_values,
+                                          hostname, preserve_pooled_values,
                                           protocol, username, password,
-                                          timeout_in_sec)
+                                          timeout)
 
 
-def config_export_domain(handle, file_dir, file_name,
-                         domain_ip, host_name,  protocol,
-                         username, password,
-                         domain_name=None, preserve_pooled_values=False,
-                         timeout_in_sec=600):
+def export_config_domain_remote(handle, file_dir, file_name,
+                                domain_ip, hostname,  protocol,
+                                username=None, password="",
+                                domain_name=None, preserve_pooled_values=False,
+                                timeout=600):
     """
-    config_export_domain helps create domain config export and download it
-    to remote location.
-    Note: Domain config export will always be remote export
+    export_config_domain_remote helps create domain export config and download
+    it to remote location.
+    Note: Domain export export config will always be remote export
 
     Args:
         handle (UcsCentralHandle): UcsCentral Connection handle
         file_dir (str): directory to download ucs backup file to
         file_name (str): name for the backup file
-                         (supported file extension is '.tgz')
-        timeout_in_sec (number) : time in seconds for which method waits
+                         (supported file extension is '.xml')
+        timeout (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         domain_ip(str): IP of domain, set 'None' if domain_name is valid
         domain_name(str): Domain name, valid only if domain_ip is None
@@ -508,54 +679,80 @@ def config_export_domain(handle, file_dir, file_name,
     Example:
         file_dir = "/home/user/backup"\n
         file_name = "config_backup.xml"\n
-        config_export_domain(handle, file_dir=test_support,
+        export_config_domain(handle, file_dir=test_support,
                     file_name=file_name,
                     username='admin', password='password',
                     domain_ip='10.10.10.1', protocol='scp',
                     hostname='192.168.1.1')
     """
     backup_type = "config-all"
-    return _backup_or_configexport_domain(handle, backup_type, file_dir,
+    return _backup_or_exportconfig_domain(handle, backup_type, file_dir,
                                           file_name, domain_ip, domain_name,
-                                          host_name, preserve_pooled_values,
+                                          hostname, preserve_pooled_values,
                                           protocol, username, password,
-                                          timeout_in_sec)
+                                          timeout)
 
 
-def config_import_ucscentral(handle, file_dir, file_name, merge=False,
-                             remote_enabled=False, protocol=None,
-                             host_name="localhost",
-                             username=None, password=None):
+def _is_backup_file_on_server(handle, hostname_str, backup_file):
+
+    backup_path_str = "/" + hostname_str + "/cfg-backups"
+    filter_str = '(file_path, %s, type="eq")' % backup_path_str
+
+    backups = handle.query_classid(
+        class_id='ConfigBackup', filter_str=filter_str)
+
+    for backup in backups:
+        if backup.file_name == backup_file:
+            log.debug("Backup file '%s' exist on ucscentral" % backup_file)
+            return True
+    return False
+
+
+def _import_config(handle, file_name, file_location="ucscentral",
+                   file_dir=None, merge=True, protocol=None,
+                   hostname="localhost",
+                   username=None, password="", timeout=120):
     """
-    This operation uploads a UcsCentral config export taken earlier via GUI
-    or config_export_ucscentral operation. User can perform an import while the
-    system is up and running.
+    This internal method imports a UcsCentral config from local, remote or
+    ucscentral
 
     Args:
         handle (UcsCentralHandle): connection handle
-        file_dir (str): directory containing ucs backup file
         file_name (str): backup file name to be imported
+        file_location (str): file location where the config file is, it can be:
+                             ['ucscentral','local','remote']
+        file_dir (str): directory containing ucscentral backup file,
+                        used only for import from local or remote
         merge (boolean): True/False, specifies whether to merge the backup
                         config with the existing UCS Central configuration
 
-        remote_enabled (boolean): True if Remote import is enabled
-                                  False - by default
         protocol (str): Transfer protocol for remote import
                         ['ftp','sftp','tftp','scp']
         hostname (str): Hostname/IP for the remote import
         username (str): Username for remote import
         password (str): Password for remote import
+        timeout (number) : time in seconds for which method waits for
+                                  import operation success before timing out
 
     Example:
         file_dir = "/home/user/backup"\n
         file_name = "config_export.tgz"\n
-        config_import_ucscentral(handle, file_dir=test_support,
-                                 file_name=file_name, merge=True)\n
+        import from ucscentral:
+        _import_config(handle, file_name=file_name,
+                       file_location="ucscentral")
 
-        config_import_ucscentral(handle, file_dir=test_support,
-                                 file_name=file_name, remote_enabled=True,
-                                 protocol='scp',hostname='192.168.1.1',
-                                 username='admin',password='password')\n
+        import from local:
+        _import_config(handle, file_name=file_name,
+                       file_location="local",
+                       file_dir=file_dir,
+                       merge=True)\n
+
+        import from remote:
+        _import_config(handle, file_name=file_name,
+                       file_location="remote",
+                       file_dir=file_dir
+                       protocol='scp',hostname='192.168.1.1',
+                       username='admin',password='password')\n
 
     """
 
@@ -563,50 +760,720 @@ def config_import_ucscentral(handle, file_dir, file_name, merge=False,
     from ..mometa.mgmt.MgmtDataImporter import MgmtDataImporter, \
         MgmtDataImporterConsts
 
-    if not file_dir:
-        raise UcsCentralValidationException("Missing file_dir argument")
     if not file_name:
         raise UcsCentralValidationException("Missing file_name argument")
 
-    file_path = os.path.join(file_dir, file_name)
+    if file_location != "ucscentral":
+        if not file_dir:
+            raise UcsCentralValidationException("Missing file_dir argument")
 
     if (not file_name.endswith('.tgz')):
         raise UcsCentralValidationException("file_name must be .tgz format")
 
     top_system = TopSystem()
-    if remote_enabled:
+
+    if file_location == "remote":
+        file_path = os.path.join(file_dir, file_name)
+        _validate_remote_host_args(protocol, hostname, username, password)
         mgmt_importer = MgmtDataImporter(
             parent_mo_or_dn=top_system,
-            hostname=host_name,
+            hostname=hostname,
             remote_file=file_path,
             proto=protocol,
             user=username,
             pwd=password,
             admin_state=MgmtDataImporterConsts.ADMIN_STATE_ENABLED)
-    else:
+
+    elif file_location == "local":
+        file_path = os.path.join(file_dir, file_name)
         if not os.path.exists(file_path):
-            raise UcsCentralValidationException("Backup File not found <%s>" %
-                                                file_path)
+            raise UcsCentralOperationError("Import config",
+                                           "Backup File '%s' not found" %
+                                           file_path)
         mgmt_importer = MgmtDataImporter(
             parent_mo_or_dn=top_system,
-            hostname=host_name,
+            hostname="localhost",
             remote_file='/' + file_name,
             proto=MgmtDataImporterConsts.PROTO_HTTP,
             admin_state=MgmtDataImporterConsts.ADMIN_STATE_ENABLED)
+
+    elif file_location == "ucscentral":
+        if not _is_backup_file_on_server(handle, "ucs-central", file_name):
+            raise UcsCentralOperationError("Import config",
+                                           "Backup File '%s' not found "
+                                           "on ucscentral" % file_name)
+        mgmt_importer = MgmtDataImporter(
+            parent_mo_or_dn=top_system,
+            hostname="localhost",
+            remote_file='/ucs-central/cfg-backups/' + file_name,
+            proto=MgmtDataImporterConsts.PROTO_TFTP,
+            admin_state=MgmtDataImporterConsts.ADMIN_STATE_ENABLED)
+
+    else:
+        raise UcsCentralOperationError(
+                "Import config",
+                "Invalid file_location argument."
+                "It must be either ucscentral,local or remote")
 
     if merge:
         mgmt_importer.action = MgmtDataImporterConsts.ACTION_MERGE
     else:
         mgmt_importer.action = MgmtDataImporterConsts.ACTION_REPLACE
 
-    if not remote_enabled:
-        uri_suffix = "operations/file-%s/importconfig.txt?Cookie=%s" % (
-            file_name, handle.cookie)
-        handle.file_upload(url_suffix=uri_suffix,
-                           file_dir=file_dir,
-                           file_name=file_name)
+    if file_location == "local":
+        try:
+            log.debug("Start uploading config")
+            uri_suffix = "operations/file-%s/importconfig.txt?Cookie=%s" % (
+                         file_name, handle.cookie)
+            handle.file_upload(url_suffix=uri_suffix,
+                               file_dir=file_dir,
+                               file_name=file_name)
+
+        except Exception as err:
+            UcsCentralWarning(str(err))
+            raise UcsCentralOperationError("Upload config", "upload failed")
 
     handle.add_mo(mgmt_importer, modify_present=True)
     handle.commit()
 
+    duration = timeout
+    poll_interval = 2
+    log.debug("Importing ucscentral config")
+    while True:
+        mgmt_importer = handle.query_dn(dn=mgmt_importer.dn)
+        admin_state = mgmt_importer.admin_state
+
+        # Break condition:- if state id disabled then break
+        if admin_state == MgmtDataImporterConsts.ADMIN_STATE_DISABLED:
+            break
+
+        time.sleep(min(duration, poll_interval))
+        duration = max(0, (duration - poll_interval))
+        if duration == 0:
+            raise UcsCentralOperationError(
+                  "Import config", "operation timed out")
+
+    if mgmt_importer.over_all_status != \
+            MgmtDataImporterConsts.OVER_ALL_STATUS_ALL_SUCCESS:
+            raise UcsCentralOperationError(
+                  "Import config",
+                  ("operational status %s " % mgmt_importer.over_all_status))
+
+    log.debug("Import config to ucscentral was successfull")
     return mgmt_importer
+
+
+def import_config_ucscentral(handle, file_name, merge=True,
+                             timeout=120):
+    """
+    import_config_ucscentral imports exisiting UcsCentral config ie.available
+    on UcsCentral(taken via schedule_export_config) to the UcsCentral
+
+    Args:
+        handle (UcsCentralHandle): connection handle
+        file_name (str): backup file name to be imported
+        merge (boolean): True/False, specifies whether to merge the backup
+                        config with the existing UCS Central configuration
+        timeout (number) : time in seconds for which method waits for
+                                  import operation success before timing out
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "config_export.tgz"\n
+        import from ucscentral:
+        import_config_ucscentral(handle, file_name=file_name)
+    """
+    _import_config(handle, file_name=file_name, merge=merge,
+                   file_location="ucscentral",
+                   hostname="localhost",
+                   timeout=timeout)
+
+
+def import_config_local(handle, file_dir, file_name, merge=True,
+                        timeout=120):
+    """
+    import_config_ucscentral imports UcsCentral config available locally to
+    UcsCentral
+
+    Args:
+        handle (UcsCentralHandle): connection handle
+        file_dir (str): directory containing ucscentral backup file,
+        file_name (str): backup file name to be imported
+        merge (boolean): True/False, specifies whether to merge the backup
+                        config with the existing UCS Central configuration
+        timeout (number) : time in seconds for which method waits for
+                                  import operation success before timing out
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "config_export.tgz"\n
+
+        import from local:
+        import_config_local(handle, file_name=file_name,
+                            file_dir=file_dir,
+                            merge=True)\n
+
+    """
+    _import_config(handle, file_name=file_name, file_dir=file_dir, merge=merge,
+                   file_location="local",
+                   hostname="localhost",
+                   timeout=timeout)
+
+
+def import_config_remote(handle, file_dir, file_name, hostname,
+                         merge=True,
+                         protocol="scp",
+                         username=None, password="",
+                         timeout=120):
+    """
+    import_config_remote imports UcsCentral config from remote location to
+    UcsCentral
+
+    Args:
+        handle (UcsCentralHandle): connection handle
+        file_dir (str): directory containing ucscentral backup file,
+        file_name (str): backup file name to be imported
+        hostname (str): Hostname/IP for the remote import
+        merge (boolean): True/False, specifies whether to merge the backup
+                        config with the existing UCS Central configuration
+        protocol (str): Transfer protocol for remote import
+                        ['ftp','sftp','tftp','scp']
+        username (str): Username for remote import
+        password (str): Password for remote import
+        timeout (number) : time in seconds for which method waits for
+                                  import operation success before timing out
+
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "config_export.tgz"\n
+
+        import from remote:
+        import_config_remote(handle, file_name=file_name,
+                             file_dir=file_dir
+                             protocol='scp',hostname='192.168.1.1',
+                             username='admin',password='password')\n
+
+    """
+    _import_config(handle, file_name=file_name, file_dir=file_dir, merge=merge,
+                   file_location="remote",
+                   protocol=protocol, hostname=hostname,
+                   username=username, password=password,
+                   timeout=timeout)
+
+
+def import_config_domain(handle, to_domain_ip, from_domain_ip, config_file,
+                         merge=True,
+                         to_domain_name=None, from_domain_name=None,
+                         timeout=120):
+    """
+    This operation imports UcsCentral Domain's config created earlier via
+    schedule backup of the same or other Domains.
+    Note: Only config-all backup on UcsCentral are available for import, local
+    or remote import is not supported for domain
+
+    Args:
+        handle (UcsCentralHandle): connection handle
+        to_domain_ip(str): IP of domain To which you want to import
+                           set 'None' if domain_name is valid
+        from_domain_ip(str): IP of domain From which you want to import
+                             set 'None' if domain_name is valid
+        config_file(str): From domain's config file which you want to import
+        merge (boolean): True/False, specifies whether to merge the backup
+                         config with the existing domain configuration
+        to_domain_name(str): to domain name, valid only if to_domain_ip is None
+        from_domain_name(str): from domain name, valid only if
+                               from_domain_ip is None
+        timeout (number) : time in seconds for which method waits for
+                                  import operation success before timing out
+
+    Example:
+        import_config_domain(handle, to_domain_ip="10.10.10.100",
+                             from_domain_ip="192.168.1.1",
+                             config_file="all-cfg.1.tgz")\n
+
+    """
+
+    from ..mometa.mgmt.MgmtImporter import MgmtImporter, MgmtImporterConsts
+    from .ucscentraldomain import get_domain, _is_domain_available
+
+    to_domain = get_domain(handle, to_domain_ip, to_domain_name)
+
+    if not _is_domain_available(handle, to_domain.id):
+        raise UcsCentralOperationError("Import config domain",
+                                       "Domain with IP %s or name %s not "
+                                       "registered or lost visibility "
+                                       "with UcsCentral" %
+                                       (to_domain_ip, to_domain_name))
+
+    from_domain = get_domain(handle, from_domain_ip, from_domain_name)
+
+    if not _is_domain_available(handle, from_domain.id):
+        raise UcsCentralOperationError("Import config domain",
+                                       "Domain with IP %s or name %s not "
+                                       "registered or lost visibility "
+                                       "with UcsCentral" %
+                                       (from_domain_ip, from_domain_name))
+
+    if not _is_backup_file_on_server(handle, from_domain.address, config_file):
+        raise UcsCentralOperationError("Import config domain",
+                                       "Backup File '%s' not found "
+                                       "on ucscentral" % config_file)
+
+    filter_str = '(connector_id, %s, type="eq")' % to_domain.id
+
+    consumer_inst = handle.query_classid(
+        class_id='ConsumerInst', filter_str=filter_str)
+
+    if (len(consumer_inst) <= 0):
+        raise UcsCentralOperationError("Import config domain",
+                                       "Unable to get Domain instance"
+                                       "with IP %s for import " %
+                                       to_domain.address)
+
+    consumer_dn = consumer_inst[0].dn
+    top_system = handle.query_dn("sys")
+
+    mgmt_importer = MgmtImporter(
+        parent_mo_or_dn=consumer_dn,
+        hostname=top_system.address,
+        remote_file='/' + from_domain.address + '/cfg-backups/' + config_file,
+        proto=MgmtImporterConsts.PROTO_TFTP,
+        admin_state=MgmtImporterConsts.ADMIN_STATE_ENABLED)
+
+    if merge:
+        mgmt_importer.action = MgmtImporterConsts.ACTION_MERGE
+    else:
+        mgmt_importer.action = MgmtImporterConsts.ACTION_REPLACE
+
+    handle.add_mo(mgmt_importer, modify_present=True)
+    handle.commit(dme="operation-mgr")
+
+    duration = timeout
+    poll_interval = 2
+    log.debug("Importing domain config")
+    while True:
+        mgmt_importer = handle.query_dn(
+                dn=mgmt_importer.dn,
+                dme="operation-mgr")
+        admin_state = mgmt_importer.admin_state
+
+        # Break condition:- if state id disabled then break
+        if admin_state == MgmtImporterConsts.ADMIN_STATE_DISABLED:
+            break
+
+        time.sleep(min(duration, poll_interval))
+        duration = max(0, (duration - poll_interval))
+        if duration == 0:
+            raise UcsCentralOperationError(
+                  "Import config", "operation timed out")
+
+    if mgmt_importer.op_status != \
+            MgmtImporterConsts.OP_STATUS_ALL_SUCCESS:
+            raise UcsCentralOperationError(
+                  "Import config",
+                  ("operational status %s " % mgmt_importer.op_status))
+
+    log.debug("Import config to domain was successfull")
+    return mgmt_importer
+
+
+def _schedule_backup(handle, descr, sched_name, max_bkup_files, remote_enabled,
+                     protocol, hostname, file_path,
+                     username, password, parent_mo_or_dn):
+
+    """
+    Internal method to schedule and take remote backup of UcsCentral and Domain
+    full-state backup
+    """
+    from ..mometa.mgmt.MgmtBackupPolicy import MgmtBackupPolicy, \
+        MgmtBackupPolicyConsts
+
+    if remote_enabled:
+        if not file_path:
+            raise UcsCentralValidationException("Missing file_path argument")
+
+        _validate_remote_host_args(protocol, hostname, username, password)
+        proto = protocol
+        host = hostname
+        remote_file = file_path
+        user = username
+        pwd = password
+    else:
+        proto = MgmtBackupPolicyConsts.PROTO_NFS_COPY
+        host = ""
+        remote_file = " "
+        user = ""
+        pwd = ""
+
+    backup_pol = MgmtBackupPolicy(
+            parent_mo_or_dn=parent_mo_or_dn,
+            descr=descr,
+            admin_state=MgmtBackupPolicyConsts.ADMIN_STATE_ENABLE,
+            sched_name=sched_name,
+            max_files=str(max_bkup_files),
+            proto=proto,
+            host=host,
+            remote_file=remote_file,
+            user=user,
+            pwd=pwd,
+            name="default")
+
+    handle.add_mo(backup_pol, modify_present=True)
+    handle.commit()
+
+    return backup_pol
+
+
+def schedule_backup(handle, descr="Database Backup Policy",
+                    sched_name="global-default", max_bkup_files="2",
+                    remote_enabled=False, protocol=None,
+                    hostname=None, file_path=None,
+                    username=None, password=""):
+    """
+    schedule_backup helps schedule and optionally take remote backup of
+    UcsCentral full-state backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        descr (str): Description of the policy
+        sched_name (str): Name of the schedule
+        max_bkup_files (str): Number of files to keep as backup
+        remote_enabled (boolean): True if Remote backup is enabled
+                                  False - by default
+        protocol (str): Transfer protocol for remote backup
+                        ['ftp','sftp','tftp','scp']
+        hostname (str): Hostname/IP for the remote backup
+        file_path (str): Absolute file path on remote host
+        username (str): Username for remote backup
+        password (str): Password for remote backup
+
+    Example:
+        file_path = "/ws/usr-admin/backup.tgz"\n
+        schedule_backup(handle, max_bkup_files=3)
+
+        schedule_backup(handle, file_path=file_path,
+                        remote_enabled=True,
+                        protocol='scp',hostname='192.168.1.1',
+                        username='admin',password='password')\n
+
+    """
+
+    return _schedule_backup(
+           handle, descr=descr, sched_name=sched_name,
+           max_bkup_files=max_bkup_files,
+           remote_enabled=remote_enabled, protocol=protocol,
+           hostname=hostname, file_path=file_path,
+           username=username, password=password,
+           parent_mo_or_dn=ucscentral_base_dn)
+
+
+def schedule_backup_domain(handle, descr="Database Backup Policy",
+                           sched_name="global-default", max_bkup_files="2",
+                           remote_enabled=False, protocol=None,
+                           hostname=None, file_path=None,
+                           username=None, password="",
+                           domain_group="root"):
+    """
+    schedule_backup_domain helps schedule and optionally take remote backup of
+    domain's full-state backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        descr (str): Description of the policy
+        sched_name (str): Name of the schedule
+        max_bkup_files (str): Number of files to keep as backup
+        remote_enabled (boolean): True if Remote backup is enabled
+                                  False - by default
+        protocol (str): Transfer protocol for remote backup
+                        ['ftp','sftp','tftp','scp']
+        hostname (str): Hostname/IP for the remote backup
+        file_path (str): Absolute file path on remote host
+        username (str): Username for remote backup
+        password (str): Password for remote backup
+        domain_group (str): Fully qualified domain group name
+
+    Example:
+        file_path = "/ws/usr-admin/backup.tgz"\n
+        schedule_backup_domain(handle, max_bkup_files=3)
+
+        schedule_backup_domain(handle, file_path=file_path,
+                               remote_enabled=True,
+                               protocol='scp',hostname='192.168.1.1',
+                               username='admin',password='password',
+                               domain_group="root/demo_domgrp")\n
+
+    """
+
+    from ucscentralsdk.utils.ucscentraldomain import get_domain_group_dn
+    domain_group_dn = get_domain_group_dn(handle, domain_group)
+
+    return _schedule_backup(
+           handle, descr=descr, sched_name=sched_name,
+           max_bkup_files=max_bkup_files,
+           remote_enabled=remote_enabled, protocol=protocol,
+           hostname=hostname, file_path=file_path,
+           username=username, password=password,
+           parent_mo_or_dn=domain_group_dn)
+
+
+def _schedule_export_config(handle, descr, sched_name,
+                            max_bkup_files, remote_enabled,
+                            protocol, hostname, file_path,
+                            username, password,
+                            parent_mo_or_dn):
+
+    """
+    Internal method to schedule and take remote backup of UcsCentral and Domain
+    config-all backup
+    """
+    from ..mometa.mgmt.MgmtCfgExportPolicy import MgmtCfgExportPolicy, \
+        MgmtCfgExportPolicyConsts
+
+    if remote_enabled:
+        if not file_path:
+            raise UcsCentralValidationException("Missing file_path argument")
+
+        _validate_remote_host_args(protocol, hostname, username, password)
+        proto = protocol
+        host = hostname
+        remote_file = file_path
+        user = username
+        pwd = password
+    else:
+        proto = MgmtCfgExportPolicyConsts.PROTO_NFS_COPY
+        host = ""
+        remote_file = " "
+        user = ""
+        pwd = ""
+
+    cfg_export_pol = MgmtCfgExportPolicy(
+            parent_mo_or_dn=parent_mo_or_dn,
+            descr=descr,
+            admin_state=MgmtCfgExportPolicyConsts.ADMIN_STATE_ENABLE,
+            sched_name=sched_name,
+            max_files=str(max_bkup_files),
+            proto=proto,
+            host=host,
+            remote_file=remote_file,
+            user=user,
+            pwd=pwd,
+            name="default")
+
+    handle.add_mo(cfg_export_pol, modify_present=True)
+    handle.commit()
+
+    return cfg_export_pol
+
+
+def schedule_export_config(handle, descr="Configuration Export "
+                           "Policy", sched_name="global-default",
+                           max_bkup_files="2",
+                           remote_enabled=False, protocol=None,
+                           hostname="", file_path="",
+                           username=None, password=""):
+    """
+    schedule_export_config helps schedule and optionally take remote backup of
+    UcsCentral's config-all backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        descr (str): Description of the policy
+        sched_name (str): Name of the schedule
+        max_bkup_files (str): Number of files to keep as backup
+        remote_enabled (boolean): True if Remote backup is enabled
+                                  False - by default
+        protocol (str): Transfer protocol for remote backup
+                        ['ftp','sftp','tftp','scp']
+        hostname (str): Hostname/IP for the remote backup
+        file_path (str): Absolute file path on remote host
+        username (str): Username for remote backup
+        password (str): Password for remote backup
+
+    Example:
+        file_path = "/ws/usr-admin/config.tgz"\n
+        schedule_export_config(handle, max_bkup_files=3)
+
+        schedule_export_config(handle, file_path=file_path,
+                               remote_enabled=True,
+                               protocol='scp',hostname='192.16.1.1',
+                               username='admin',password='pass')\n
+
+    """
+
+    return _schedule_export_config(
+           handle, descr=descr, sched_name=sched_name,
+           max_bkup_files=max_bkup_files,
+           remote_enabled=remote_enabled, protocol=protocol,
+           hostname=hostname, file_path=file_path,
+           username=username, password=password,
+           parent_mo_or_dn=ucscentral_base_dn)
+
+
+def schedule_export_config_domain(handle, descr="Configuration Export "
+                                  "Policy", sched_name="global-default",
+                                  max_bkup_files="2",
+                                  remote_enabled=False, protocol=None,
+                                  hostname="", file_path="",
+                                  username=None, password=None,
+                                  domain_group="root"):
+    """
+    schedule_export_config_domain helps schedule and optionally take remote
+    backup of domain's config-all backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        descr (str): Description of the policy
+        sched_name (str): Name of the schedule
+        max_bkup_files (str): Number of files to keep as backup
+        remote_enabled (boolean): True if Remote backup is enabled
+                                  False - by default
+        protocol (str): Transfer protocol for remote backup
+                        ['ftp','sftp','tftp','scp']
+        hostname (str): Hostname/IP for the remote backup
+        file_path (str): Absolute file path on remote host
+        username (str): Username for remote backup
+        password (str): Password for remote backup
+        domain_group (str): Fully qualified domain group name
+
+    Example:
+        file_path = "/ws/usr-admin/config.tgz"\n
+        schedule_export_config_domain(handle, max_bkup_files=3)
+
+        schedule_export_config_domain(handle, file_path=file_path,
+                                      remote_enabled=True,
+                                      protocol='scp',hostname='192.16.1.1',
+                                      username='admin',password='pass',
+                                      domain_group="root/demo_domgrp")\n
+
+    """
+    from ucscentralsdk.utils.ucscentraldomain import get_domain_group_dn
+    domain_group_dn = get_domain_group_dn(handle, domain_group)
+
+    return _schedule_export_config(
+           handle, descr=descr, sched_name=sched_name,
+           max_bkup_files=max_bkup_files,
+           remote_enabled=remote_enabled, protocol=protocol,
+           hostname=hostname, file_path=file_path,
+           username=username, password=password,
+           parent_mo_or_dn=domain_group_dn)
+
+
+def remove_schedule_backup(handle):
+    """
+    remvove_schedule_backup removes the schedule of UcsCentral's
+    full backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+
+    Example:
+        remove_schedule_backup(handle)
+
+    """
+
+    from ..mometa.mgmt.MgmtBackupPolicy import MgmtBackupPolicyConsts
+    dn = ucscentral_base_dn + "/db-backup-policy-default"
+
+    mo = handle.query_dn(dn=dn)
+    if not mo:
+        raise UcsCentralOperationError("Remove backup schedule",
+                                       "Backup Schedule doesn't exist")
+
+    mo.admin_state = MgmtBackupPolicyConsts.ADMIN_STATE_DISABLE
+
+    handle.set_mo(mo)
+    handle.commit()
+
+
+def remove_schedule_export_config(handle):
+    """
+    remvove_schedule_export_config removes the schedule of
+    UcsCentral config-all backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+
+    Example:
+        remove_schedule_export_config(handle)
+
+    """
+
+    from ..mometa.mgmt.MgmtCfgExportPolicy import MgmtCfgExportPolicyConsts
+    dn = ucscentral_base_dn + "/cfg-exp-policy-default"
+
+    mo = handle.query_dn(dn=dn)
+    if not mo:
+        raise UcsCentralOperationError("Remove export config",
+                                       "Export config schedule doesn't exist")
+
+    mo.admin_state = MgmtCfgExportPolicyConsts.ADMIN_STATE_DISABLE
+
+    handle.set_mo(mo)
+    handle.commit()
+
+
+def remove_schedule_backup_domain(handle, domain_group="root"):
+    """
+    remvove_schedule_backup_domain removes the schedule policy of Domain's
+    full backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        domain_group (str): Fully qualified domain group name
+
+    Example:
+        remove_schedule_backup_domain(handle, domain_group="root/demo_domgrp")
+
+    """
+
+    from ..mometa.mgmt.MgmtBackupPolicy import MgmtBackupPolicyConsts
+    from ucscentralsdk.utils.ucscentraldomain import get_domain_group_dn
+    domain_group_dn = get_domain_group_dn(handle, domain_group)
+
+    dn = domain_group_dn + "/db-backup-policy-default"
+
+    mo = handle.query_dn(dn=dn)
+    if not mo:
+        raise UcsCentralOperationError("Remove backup schedule",
+                                       "Backup Schedule doesn't exist")
+
+    mo.admin_state = MgmtBackupPolicyConsts.ADMIN_STATE_DISABLE
+
+    handle.set_mo(mo)
+    if domain_group != "root":
+        handle.remove_mo(mo)
+    handle.commit()
+
+
+def remove_schedule_export_config_domain(handle, domain_group="root"):
+    """
+    remvove_schedule_export_config_domain removes the schedule policy of
+    Domain's config-all backup.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral Connection handle
+        domain_group (str): Fully qualified domain group name
+
+    Example:
+        remove_schedule_export_config_domain(handle,
+                               domain_group="root/demo_domgrp")\n
+
+    """
+
+    from ..mometa.mgmt.MgmtCfgExportPolicy import MgmtCfgExportPolicyConsts
+    from ucscentralsdk.utils.ucscentraldomain import get_domain_group_dn
+    domain_group_dn = get_domain_group_dn(handle, domain_group)
+
+    dn = domain_group_dn + "/cfg-exp-policy-default"
+
+    mo = handle.query_dn(dn=dn)
+    if not mo:
+        raise UcsCentralOperationError("Remove export config",
+                                       "Export config schedule doesn't exist")
+
+    mo.admin_state = MgmtCfgExportPolicyConsts.ADMIN_STATE_DISABLE
+
+    handle.set_mo(mo)
+    if domain_group != "root":
+        handle.remove_mo(mo)
+    handle.commit()

--- a/ucscentralsdk/utils/ucscentraldomain.py
+++ b/ucscentralsdk/utils/ucscentraldomain.py
@@ -45,8 +45,9 @@ def domain_register(handle, domain_name_or_ip,
         PolicyControlEpOp, PolicyControlEpOpConsts
 
     if VERSION(get_ucscentral_version(handle)) < VERSION("1.5"):
-        raise UcsCentralValidationException("Operation only supported from "
-            "version 1.5 onwards")
+        raise UcsCentralOperationError(
+                "Domain register",
+                "Operation only supported from version 1.5 onwards")
 
     if is_domain_registered(handle, domain_name_or_ip):
         domain_dn = "holder/domain-ep/control-ep-" + domain_name_or_ip
@@ -109,7 +110,7 @@ def is_domain_registered(handle, domain_name_or_ip):
 
     if domain_register:
         if domain_register.registration_state == \
-            PolicyControlEpOpConsts.REGISTRATION_STATE_REGISTERED:
+                PolicyControlEpOpConsts.REGISTRATION_STATE_REGISTERED:
             return True
         else:
             log.debug("Domain registration is in-progress or has failed")
@@ -140,22 +141,25 @@ def domain_unregister(handle, domain_name_or_ip):
         PolicyControlEpOpConsts
 
     if VERSION(get_ucscentral_version(handle)) < VERSION("1.5"):
-        raise UcsCentralValidationException("Operation only supported from "
-            "version 1.5 onwards")
+        raise UcsCentralOperationError(
+                "Domain unregister",
+                "Operation only supported from version 1.5 onwards")
 
     filter_str = '(host_name_or_ip, %s, type="eq")' % domain_name_or_ip
 
     domains_registered = handle.query_classid(class_id="PolicyControlEpOp",
                                               filter_str=filter_str)
     if (len(domains_registered) <= 0):
-        raise UcsCentralValidationException(
+        raise UcsCentralOperationError(
+            "Domain unregister",
             "Domain with name or IP %s not registered with ucscentral"
             % domain_name_or_ip)
 
     domain_register = domains_registered[0]
 
     if not _is_domain_available(handle, domain_register.sys_id):
-        raise UcsCentralValidationException(
+        raise UcsCentralOperationError(
+            "Domain unregister",
             "Not able to connect with Domain %s" % domain_name_or_ip)
 
     domain_register.action_event = \
@@ -192,9 +196,10 @@ def get_domain(handle, domain_ip, domain_name=None):
         class_id='ComputeSystem', filter_str=filter_str)
 
     if (len(domain) <= 0):
-        raise UcsCentralValidationException("Domain with IP %s or name %s "
-                                            "does not exist" %
-                                            (domain_ip, domain_name))
+        raise UcsCentralOperationError("Get domain",
+                                       "Domain with IP %s or name %s "
+                                       "does not exist" %
+                                       (domain_ip, domain_name))
 
     return domain[0]
 
@@ -218,17 +223,19 @@ def get_domain_operational_status(handle, domain_ip, domain_name=None):
     domain = get_domain(handle, domain_ip, domain_name)
 
     if not domain:
-        raise UcsCentralValidationException("Domain with IP %s or name %s "
-                                            "does not exist" %
-                                            (domain_ip, domain_name))
+        raise UcsCentralOperationError("Get domain operational status",
+                                       "Domain with IP %s or name %s "
+                                       "does not exist" %
+                                       (domain_ip, domain_name))
 
     extpol_client_dn = "extpol/reg/clients/client-" + domain.id
     extpol_client = handle.query_dn(extpol_client_dn)
 
     if not extpol_client:
-        raise UcsCentralValidationException("Domain with IP %s or name %s "
-                                            "does not exist" %
-                                            (domain_ip, domain_name))
+        raise UcsCentralOperationError("Get domain operational status",
+                                       "Domain with IP %s or name %s "
+                                       "does not exist" %
+                                       (domain_ip, domain_name))
     return extpol_client.oper_state
 
 
@@ -281,7 +288,8 @@ def domain_group_create(handle, name,
 
     org = handle.query_dn(parent_dn)
     if not org:
-        raise UcsCentralValidationException(
+        raise UcsCentralOperationError(
+            "Domain group create",
             "org '%s' does not exist" % parent_dn)
 
     mo = OrgDomainGroup(parent_mo_or_dn=org.dn,
@@ -318,8 +326,9 @@ def get_domain_group_dn(handle, domain_group):
     dn = handle.query_dn(domain_group_dn)
 
     if not dn:
-        raise UcsCentralValidationException("Domain Group %s doesn't exist" %
-                                            domain_group)
+        raise UcsCentralOperationError("Get domain group dn",
+                                       "Domain Group %s doesn't exist" %
+                                       domain_group)
     return domain_group_dn
 
 

--- a/ucscentralsdk/utils/ucscentraltechsupport.py
+++ b/ucscentralsdk/utils/ucscentraltechsupport.py
@@ -148,16 +148,33 @@ def download_tech_support(handle, name, file_dir, file_name):
         UcsCentralWarning(str(err))
 
 
-def remove_tech_support(handle, ts_mo):
+def _remove_tech_support(handle, ts_mo):
     ts_mo.admin_state = "delete"
     handle.set_mo(ts_mo)
     handle.commit()
 
 
-def get_ucscentral_tech_support(handle, file_dir=None, file_name=None,
-                                remove_from_ucscentral=False,
-                                download=True,
-                                timeout=1200):
+def get_tech_support(handle, file_dir=None, file_name=None,
+                     remove_from_ucscentral=False,
+                     download=True,
+                     timeout=1200):
+    """
+    This operation creates the technical support file for UcsCentral.
+
+    Args:
+        handle (UcsCentralHandle): UcsCentral connection handle
+        file_dir (str): directory to download techsupport file to
+        file_name (str): name for the backup file
+        remove_from_ucscentral (boolean): True/False, False - by default
+        download (boolean): True/False, True - by default
+        timeout (number) : time in seconds for which method waits
+                           for the techsupport to generate before it exits.
+    Example:
+        file_dir = "/home/user/backup"\n
+        file_name = "techsupport.tar"\n
+        get_tech_support(handle, file_dir=file_dir, file_name=file_name)
+
+    """
 
     from .ucscentralfirmware import is_local_download_supported
 
@@ -188,7 +205,7 @@ def get_ucscentral_tech_support(handle, file_dir=None, file_name=None,
 
     # remove tech support file from Ucs Central
     if remove_from_ucscentral:
-        remove_tech_support(handle, ts_mo)
+        _remove_tech_support(handle, ts_mo)
         log.debug("Removed techsupport from ucscentral")
 
 
@@ -393,7 +410,7 @@ def get_domain_tech_support(handle, domain_ip,
 
     Example:
 
-         get_domain_tech_support(handle, domain_ip='192.168.1.1'
+        get_domain_tech_support(handle, domain_ip='192.168.1.1'
                          option="ucsm")
 
         get_domain_tech_support(handle, domain_ip=None,
@@ -416,7 +433,8 @@ def get_domain_tech_support(handle, domain_ip,
     if _is_domain_available(handle, domain.id):
         domain_dn = domain.dn
     else:
-        raise UcsCentralValidationException(
+        raise UcsCentralOperationError(
+            "Get domain techsupport",
             "Domain with IP %s or name %s not registered or "
             "lost visibility with ucscentral" %
             (domain_ip, domain_name))


### PR DESCRIPTION
- New Schedule backup/export config APIs and remove schedule backup/export config APIs
- New import config for domain API.
- Added option to have import from ucscentral for import_config_ucscentral()
- Added force option in set_prop_multiple(), to support create APIs with extra key-value pairs arguments (kwargs). This is mainly to support future ucscentral version compatibility.

Signed-off-by: Parag Shah <parag.may4@gmail.com>